### PR TITLE
Fix: Adjust header following the license change

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -13,7 +13,7 @@ use Ergebnis\PhpCsFixer;
 $header = <<<'TXT'
 @package   mod_matrix
 @copyright 2020, New Vector Ltd (Trading as Element)
-@license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+@license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
 TXT;
 
 $config = PhpCsFixer\Config\Factory::fromRuleSet(new PhpCsFixer\Config\RuleSet\Php73($header), [

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 use Ergebnis\PhpCsFixer;

--- a/backup/moodle2/backup_matrix_activity_structure_step.class.php
+++ b/backup/moodle2/backup_matrix_activity_structure_step.class.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 \defined('MOODLE_INTERNAL') || exit();

--- a/backup/moodle2/backup_matrix_activity_task.class.php
+++ b/backup/moodle2/backup_matrix_activity_task.class.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 \defined('MOODLE_INTERNAL') || exit();

--- a/backup/moodle2/restore_matrix_activity_structure_step.class.php
+++ b/backup/moodle2/restore_matrix_activity_structure_step.class.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 \defined('MOODLE_INTERNAL') || exit();

--- a/backup/moodle2/restore_matrix_activity_task.class.php
+++ b/backup/moodle2/restore_matrix_activity_task.class.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 \defined('MOODLE_INTERNAL') || exit();

--- a/classes/observer.php
+++ b/classes/observer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix;

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\privacy;

--- a/db/access.php
+++ b/db/access.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 \defined('MOODLE_INTERNAL') || exit();

--- a/db/events.php
+++ b/db/events.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 use mod_matrix\observer;

--- a/db/install.php
+++ b/db/install.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 \defined('MOODLE_INTERNAL') || exit();

--- a/db/uninstall.php
+++ b/db/uninstall.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 \defined('MOODLE_INTERNAL') || exit();

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 \defined('MOODLE_INTERNAL') || exit();

--- a/lang/en/matrix.php
+++ b/lang/en/matrix.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 use mod_matrix\Moodle;

--- a/lib.php
+++ b/lib.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 use mod_matrix\Container;

--- a/mod_form.php
+++ b/mod_form.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 \defined('MOODLE_INTERNAL') || exit();

--- a/settings.php
+++ b/settings.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 use mod_matrix\Matrix;

--- a/src/Container.php
+++ b/src/Container.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix;

--- a/src/Matrix/Application/Api.php
+++ b/src/Matrix/Application/Api.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Matrix\Application;

--- a/src/Matrix/Application/RoomService.php
+++ b/src/Matrix/Application/RoomService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Matrix\Application;

--- a/src/Matrix/Domain/AccessToken.php
+++ b/src/Matrix/Domain/AccessToken.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Matrix\Domain;

--- a/src/Matrix/Domain/EventType.php
+++ b/src/Matrix/Domain/EventType.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Matrix\Domain;

--- a/src/Matrix/Domain/Homeserver.php
+++ b/src/Matrix/Domain/Homeserver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Matrix\Domain;

--- a/src/Matrix/Domain/Membership.php
+++ b/src/Matrix/Domain/Membership.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Matrix\Domain;

--- a/src/Matrix/Domain/PowerLevel.php
+++ b/src/Matrix/Domain/PowerLevel.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Matrix\Domain;

--- a/src/Matrix/Domain/RoomId.php
+++ b/src/Matrix/Domain/RoomId.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Matrix\Domain;

--- a/src/Matrix/Domain/RoomName.php
+++ b/src/Matrix/Domain/RoomName.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Matrix\Domain;

--- a/src/Matrix/Domain/RoomTopic.php
+++ b/src/Matrix/Domain/RoomTopic.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Matrix\Domain;

--- a/src/Matrix/Domain/StateKey.php
+++ b/src/Matrix/Domain/StateKey.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Matrix\Domain;

--- a/src/Matrix/Domain/Url.php
+++ b/src/Matrix/Domain/Url.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Matrix\Domain;

--- a/src/Matrix/Domain/UserId.php
+++ b/src/Matrix/Domain/UserId.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Matrix\Domain;

--- a/src/Matrix/Domain/UserIdCollection.php
+++ b/src/Matrix/Domain/UserIdCollection.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Matrix\Domain;

--- a/src/Matrix/Domain/Username.php
+++ b/src/Matrix/Domain/Username.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Matrix\Domain;

--- a/src/Matrix/Infrastructure/CurlBasedHttpClient.php
+++ b/src/Matrix/Infrastructure/CurlBasedHttpClient.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Matrix\Infrastructure;

--- a/src/Matrix/Infrastructure/HttpClient.php
+++ b/src/Matrix/Infrastructure/HttpClient.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Matrix\Infrastructure;

--- a/src/Matrix/Infrastructure/HttpClientBasedApi.php
+++ b/src/Matrix/Infrastructure/HttpClientBasedApi.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Matrix\Infrastructure;

--- a/src/Moodle/Domain/Course.php
+++ b/src/Moodle/Domain/Course.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Moodle\Domain;

--- a/src/Moodle/Domain/CourseFullName.php
+++ b/src/Moodle/Domain/CourseFullName.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Moodle\Domain;

--- a/src/Moodle/Domain/CourseId.php
+++ b/src/Moodle/Domain/CourseId.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Moodle\Domain;

--- a/src/Moodle/Domain/CourseNotFound.php
+++ b/src/Moodle/Domain/CourseNotFound.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Moodle\Domain;

--- a/src/Moodle/Domain/CourseRepository.php
+++ b/src/Moodle/Domain/CourseRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Moodle\Domain;

--- a/src/Moodle/Domain/CourseShortName.php
+++ b/src/Moodle/Domain/CourseShortName.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Moodle\Domain;

--- a/src/Moodle/Domain/Group.php
+++ b/src/Moodle/Domain/Group.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Moodle\Domain;

--- a/src/Moodle/Domain/GroupId.php
+++ b/src/Moodle/Domain/GroupId.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Moodle\Domain;

--- a/src/Moodle/Domain/GroupName.php
+++ b/src/Moodle/Domain/GroupName.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Moodle\Domain;

--- a/src/Moodle/Domain/GroupNotFound.php
+++ b/src/Moodle/Domain/GroupNotFound.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Moodle\Domain;

--- a/src/Moodle/Domain/GroupRepository.php
+++ b/src/Moodle/Domain/GroupRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Moodle\Domain;

--- a/src/Moodle/Domain/SectionId.php
+++ b/src/Moodle/Domain/SectionId.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Moodle\Domain;

--- a/src/Moodle/Domain/Timestamp.php
+++ b/src/Moodle/Domain/Timestamp.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Moodle\Domain;

--- a/src/Moodle/Infrastructure/MoodleFunctionBasedCourseRepository.php
+++ b/src/Moodle/Infrastructure/MoodleFunctionBasedCourseRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Moodle\Infrastructure;

--- a/src/Moodle/Infrastructure/MoodleFunctionBasedGroupRepository.php
+++ b/src/Moodle/Infrastructure/MoodleFunctionBasedGroupRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Moodle\Infrastructure;

--- a/src/Plugin/Application/Configuration.php
+++ b/src/Plugin/Application/Configuration.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Application;

--- a/src/Plugin/Application/ModuleService.php
+++ b/src/Plugin/Application/ModuleService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Application;

--- a/src/Plugin/Application/NameService.php
+++ b/src/Plugin/Application/NameService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Application;

--- a/src/Plugin/Application/Plugin.php
+++ b/src/Plugin/Application/Plugin.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Application;

--- a/src/Plugin/Application/RoomService.php
+++ b/src/Plugin/Application/RoomService.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Application;

--- a/src/Plugin/Domain/MatrixUserIdLoader.php
+++ b/src/Plugin/Domain/MatrixUserIdLoader.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Domain;

--- a/src/Plugin/Domain/Module.php
+++ b/src/Plugin/Domain/Module.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Domain;

--- a/src/Plugin/Domain/ModuleId.php
+++ b/src/Plugin/Domain/ModuleId.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Domain;

--- a/src/Plugin/Domain/ModuleName.php
+++ b/src/Plugin/Domain/ModuleName.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Domain;

--- a/src/Plugin/Domain/ModuleNotFound.php
+++ b/src/Plugin/Domain/ModuleNotFound.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Domain;

--- a/src/Plugin/Domain/ModuleRepository.php
+++ b/src/Plugin/Domain/ModuleRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Domain;

--- a/src/Plugin/Domain/ModuleTarget.php
+++ b/src/Plugin/Domain/ModuleTarget.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Domain;

--- a/src/Plugin/Domain/ModuleTopic.php
+++ b/src/Plugin/Domain/ModuleTopic.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Domain;

--- a/src/Plugin/Domain/ModuleType.php
+++ b/src/Plugin/Domain/ModuleType.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Domain;

--- a/src/Plugin/Domain/Room.php
+++ b/src/Plugin/Domain/Room.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Domain;

--- a/src/Plugin/Domain/RoomId.php
+++ b/src/Plugin/Domain/RoomId.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Domain;

--- a/src/Plugin/Domain/RoomLink.php
+++ b/src/Plugin/Domain/RoomLink.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Domain;

--- a/src/Plugin/Domain/RoomRepository.php
+++ b/src/Plugin/Domain/RoomRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Domain;

--- a/src/Plugin/Domain/Url.php
+++ b/src/Plugin/Domain/Url.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Domain;

--- a/src/Plugin/Domain/User.php
+++ b/src/Plugin/Domain/User.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Domain;

--- a/src/Plugin/Domain/UserId.php
+++ b/src/Plugin/Domain/UserId.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Domain;

--- a/src/Plugin/Domain/UserRepository.php
+++ b/src/Plugin/Domain/UserRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Domain;

--- a/src/Plugin/Infrastructure/Action/EditMatrixUserIdAction.php
+++ b/src/Plugin/Infrastructure/Action/EditMatrixUserIdAction.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Infrastructure\Action;

--- a/src/Plugin/Infrastructure/Action/ListRoomsAction.php
+++ b/src/Plugin/Infrastructure/Action/ListRoomsAction.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Infrastructure\Action;

--- a/src/Plugin/Infrastructure/DatabaseBasedModuleRepository.php
+++ b/src/Plugin/Infrastructure/DatabaseBasedModuleRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Infrastructure;

--- a/src/Plugin/Infrastructure/DatabaseBasedRoomRepository.php
+++ b/src/Plugin/Infrastructure/DatabaseBasedRoomRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Infrastructure;

--- a/src/Plugin/Infrastructure/Form/EditMatrixUserIdForm.php
+++ b/src/Plugin/Infrastructure/Form/EditMatrixUserIdForm.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Infrastructure\Form;

--- a/src/Plugin/Infrastructure/FrontController.php
+++ b/src/Plugin/Infrastructure/FrontController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Infrastructure;

--- a/src/Plugin/Infrastructure/Installer.php
+++ b/src/Plugin/Infrastructure/Installer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Infrastructure;

--- a/src/Plugin/Infrastructure/Internationalization.php
+++ b/src/Plugin/Infrastructure/Internationalization.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Infrastructure;

--- a/src/Plugin/Infrastructure/ModuleNormalizer.php
+++ b/src/Plugin/Infrastructure/ModuleNormalizer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Infrastructure;

--- a/src/Plugin/Infrastructure/MoodleFunctionBasedMatrixUserIdLoader.php
+++ b/src/Plugin/Infrastructure/MoodleFunctionBasedMatrixUserIdLoader.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Infrastructure;

--- a/src/Plugin/Infrastructure/MoodleFunctionBasedUserRepository.php
+++ b/src/Plugin/Infrastructure/MoodleFunctionBasedUserRepository.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Infrastructure;

--- a/src/Plugin/Infrastructure/RoomNormalizer.php
+++ b/src/Plugin/Infrastructure/RoomNormalizer.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Plugin\Infrastructure;

--- a/test/DataProvider/Matrix/Domain/HomeserverProvider.php
+++ b/test/DataProvider/Matrix/Domain/HomeserverProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\DataProvider\Matrix\Domain;

--- a/test/DataProvider/Matrix/Domain/UserIdProvider.php
+++ b/test/DataProvider/Matrix/Domain/UserIdProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\DataProvider\Matrix\Domain;

--- a/test/DataProvider/Matrix/Domain/UsernameProvider.php
+++ b/test/DataProvider/Matrix/Domain/UsernameProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\DataProvider\Matrix\Domain;

--- a/test/DataProvider/Plugin/Domain/ModuleNameProvider.php
+++ b/test/DataProvider/Plugin/Domain/ModuleNameProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\DataProvider\Plugin\Domain;

--- a/test/DataProvider/Plugin/Domain/ModuleTargetProvider.php
+++ b/test/DataProvider/Plugin/Domain/ModuleTargetProvider.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\DataProvider\Plugin\Domain;

--- a/test/Unit/ContainerTest.php
+++ b/test/Unit/ContainerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit;

--- a/test/Unit/Matrix/Application/RoomServiceTest.php
+++ b/test/Unit/Matrix/Application/RoomServiceTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Matrix\Application;

--- a/test/Unit/Matrix/Domain/AccessTokenTest.php
+++ b/test/Unit/Matrix/Domain/AccessTokenTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Matrix\Domain;

--- a/test/Unit/Matrix/Domain/EventTypeTest.php
+++ b/test/Unit/Matrix/Domain/EventTypeTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Matrix\Domain;

--- a/test/Unit/Matrix/Domain/HomeserverTest.php
+++ b/test/Unit/Matrix/Domain/HomeserverTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Matrix\Domain;

--- a/test/Unit/Matrix/Domain/MembershipTest.php
+++ b/test/Unit/Matrix/Domain/MembershipTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Matrix\Domain;

--- a/test/Unit/Matrix/Domain/PowerLevelTest.php
+++ b/test/Unit/Matrix/Domain/PowerLevelTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Matrix\Domain;

--- a/test/Unit/Matrix/Domain/RoomIdTest.php
+++ b/test/Unit/Matrix/Domain/RoomIdTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Matrix\Domain;

--- a/test/Unit/Matrix/Domain/RoomNameTest.php
+++ b/test/Unit/Matrix/Domain/RoomNameTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Matrix\Domain;

--- a/test/Unit/Matrix/Domain/RoomTopicTest.php
+++ b/test/Unit/Matrix/Domain/RoomTopicTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Matrix\Domain;

--- a/test/Unit/Matrix/Domain/StateKeyTest.php
+++ b/test/Unit/Matrix/Domain/StateKeyTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Matrix\Domain;

--- a/test/Unit/Matrix/Domain/UrlTest.php
+++ b/test/Unit/Matrix/Domain/UrlTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Matrix\Domain;

--- a/test/Unit/Matrix/Domain/UserIdCollectionTest.php
+++ b/test/Unit/Matrix/Domain/UserIdCollectionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Matrix\Domain;

--- a/test/Unit/Matrix/Domain/UserIdTest.php
+++ b/test/Unit/Matrix/Domain/UserIdTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Matrix\Domain;

--- a/test/Unit/Matrix/Domain/UsernameTest.php
+++ b/test/Unit/Matrix/Domain/UsernameTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Matrix\Domain;

--- a/test/Unit/Matrix/Infrastructure/HttpClientBasedApiTest.php
+++ b/test/Unit/Matrix/Infrastructure/HttpClientBasedApiTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Matrix\Infrastructure;

--- a/test/Unit/Moodle/Domain/CourseFullNameTest.php
+++ b/test/Unit/Moodle/Domain/CourseFullNameTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Moodle\Domain;

--- a/test/Unit/Moodle/Domain/CourseIdTest.php
+++ b/test/Unit/Moodle/Domain/CourseIdTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Moodle\Domain;

--- a/test/Unit/Moodle/Domain/CourseNotFoundTest.php
+++ b/test/Unit/Moodle/Domain/CourseNotFoundTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Moodle\Domain;

--- a/test/Unit/Moodle/Domain/CourseShortNameTest.php
+++ b/test/Unit/Moodle/Domain/CourseShortNameTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Moodle\Domain;

--- a/test/Unit/Moodle/Domain/CourseTest.php
+++ b/test/Unit/Moodle/Domain/CourseTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Moodle\Domain;

--- a/test/Unit/Moodle/Domain/GroupIdTest.php
+++ b/test/Unit/Moodle/Domain/GroupIdTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Moodle\Domain;

--- a/test/Unit/Moodle/Domain/GroupNameTest.php
+++ b/test/Unit/Moodle/Domain/GroupNameTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Moodle\Domain;

--- a/test/Unit/Moodle/Domain/GroupNotFoundTest.php
+++ b/test/Unit/Moodle/Domain/GroupNotFoundTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Moodle\Domain;

--- a/test/Unit/Moodle/Domain/GroupTest.php
+++ b/test/Unit/Moodle/Domain/GroupTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Moodle\Domain;

--- a/test/Unit/Moodle/Domain/SectionIdTest.php
+++ b/test/Unit/Moodle/Domain/SectionIdTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Moodle\Domain;

--- a/test/Unit/Moodle/Domain/TimestampTest.php
+++ b/test/Unit/Moodle/Domain/TimestampTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Moodle\Domain;

--- a/test/Unit/Plugin/Application/ConfigurationTest.php
+++ b/test/Unit/Plugin/Application/ConfigurationTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Application;

--- a/test/Unit/Plugin/Application/ModuleServiceTest.php
+++ b/test/Unit/Plugin/Application/ModuleServiceTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Application;

--- a/test/Unit/Plugin/Application/NameServiceTest.php
+++ b/test/Unit/Plugin/Application/NameServiceTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Application;

--- a/test/Unit/Plugin/Application/PluginTest.php
+++ b/test/Unit/Plugin/Application/PluginTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Application;

--- a/test/Unit/Plugin/Application/RoomServiceTest.php
+++ b/test/Unit/Plugin/Application/RoomServiceTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Application;

--- a/test/Unit/Plugin/Domain/ModuleIdTest.php
+++ b/test/Unit/Plugin/Domain/ModuleIdTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Domain;

--- a/test/Unit/Plugin/Domain/ModuleNameTest.php
+++ b/test/Unit/Plugin/Domain/ModuleNameTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Domain;

--- a/test/Unit/Plugin/Domain/ModuleNotFoundTest.php
+++ b/test/Unit/Plugin/Domain/ModuleNotFoundTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Domain;

--- a/test/Unit/Plugin/Domain/ModuleTargetTest.php
+++ b/test/Unit/Plugin/Domain/ModuleTargetTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Domain;

--- a/test/Unit/Plugin/Domain/ModuleTest.php
+++ b/test/Unit/Plugin/Domain/ModuleTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Domain;

--- a/test/Unit/Plugin/Domain/ModuleTopicTest.php
+++ b/test/Unit/Plugin/Domain/ModuleTopicTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Domain;

--- a/test/Unit/Plugin/Domain/ModuleTypeTest.php
+++ b/test/Unit/Plugin/Domain/ModuleTypeTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Domain;

--- a/test/Unit/Plugin/Domain/RoomIdTest.php
+++ b/test/Unit/Plugin/Domain/RoomIdTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Domain;

--- a/test/Unit/Plugin/Domain/RoomLinkTest.php
+++ b/test/Unit/Plugin/Domain/RoomLinkTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Domain;

--- a/test/Unit/Plugin/Domain/RoomTest.php
+++ b/test/Unit/Plugin/Domain/RoomTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Domain;

--- a/test/Unit/Plugin/Domain/UrlTest.php
+++ b/test/Unit/Plugin/Domain/UrlTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_plugin\Test\Unit\Plugin\Domain;

--- a/test/Unit/Plugin/Domain/UserIdTest.php
+++ b/test/Unit/Plugin/Domain/UserIdTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Domain;

--- a/test/Unit/Plugin/Domain/UserTest.php
+++ b/test/Unit/Plugin/Domain/UserTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Domain;

--- a/test/Unit/Plugin/Infrastructure/DatabaseBasedModuleRepositoryTest.php
+++ b/test/Unit/Plugin/Infrastructure/DatabaseBasedModuleRepositoryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Infrastructure;

--- a/test/Unit/Plugin/Infrastructure/DatabaseBasedRoomRepositoryTest.php
+++ b/test/Unit/Plugin/Infrastructure/DatabaseBasedRoomRepositoryTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Infrastructure;

--- a/test/Unit/Plugin/Infrastructure/InternationalizationTest.php
+++ b/test/Unit/Plugin/Infrastructure/InternationalizationTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Infrastructure;

--- a/test/Unit/Plugin/Infrastructure/ModuleNormalizerTest.php
+++ b/test/Unit/Plugin/Infrastructure/ModuleNormalizerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Infrastructure;

--- a/test/Unit/Plugin/Infrastructure/MoodleFunctionBasedMatrixUserIdLoaderTest.php
+++ b/test/Unit/Plugin/Infrastructure/MoodleFunctionBasedMatrixUserIdLoaderTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Infrastructure;

--- a/test/Unit/Plugin/Infrastructure/RoomNormalizerTest.php
+++ b/test/Unit/Plugin/Infrastructure/RoomNormalizerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Unit\Plugin\Infrastructure;

--- a/test/Util/Helper.php
+++ b/test/Util/Helper.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Util;

--- a/test/Util/Matrix/Domain/UserIdFactory.php
+++ b/test/Util/Matrix/Domain/UserIdFactory.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 namespace mod_matrix\Test\Util\Matrix\Domain;

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 require_once __DIR__ . '/../vendor/autoload.php';

--- a/version.php
+++ b/version.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 \defined('MOODLE_INTERNAL') || exit();

--- a/view.php
+++ b/view.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 /**
  * @package   mod_matrix
  * @copyright 2020, New Vector Ltd (Trading as Element)
- * @license   https://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ * @license   https://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  */
 
 use mod_matrix\Container;


### PR DESCRIPTION
This pull request

- [x] adjusts the header following the license change
- [ ] runs `make coding-standards`

Follows #1.