### PR TITLE
Fix: Inline composite actions

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -19,9 +19,6 @@ jobs:
         php-version:
           - "7.4"
 
-        dependencies:
-          - "locked"
-
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v3"
@@ -40,19 +37,17 @@ jobs:
         run: "composer validate --ansi --strict"
 
       - name: "Determine composer cache directory"
-        uses: "ergebnis/.github/actions/composer/determine-cache-directory@1.5.0"
+        run: "echo \"COMPOSER_CACHE_DIR=$(composer config cache-dir)\" >> $GITHUB_ENV"
 
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v3"
         with:
           path: "${{ env.COMPOSER_CACHE_DIR }}"
-          key: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('composer.lock') }}"
-          restore-keys: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-"
+          key: "php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('composer.lock') }}"
+          restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
 
-      - name: "Install ${{ matrix.dependencies }} dependencies with composer"
-        uses: "ergebnis/.github/actions/composer/install@1.5.0"
-        with:
-          dependencies: "${{ matrix.dependencies }}"
+      - name: "Install locked dependencies with composer"
+        run: "composer install --ansi"
 
       - name: "Create cache directory for friendsofphp/php-cs-fixer"
         run: "mkdir -p .build/php-cs-fixer"


### PR DESCRIPTION
This pull request

- [x] inlines composite actions instead of using composite actions from [`ergebnis/.github`](https://github.com/ergebnis/.github)
