### PR TITLE
Fix: Extend the scope for valid matrix user IDs

### DIFF
--- a/src/Matrix/Domain/UserId.php
+++ b/src/Matrix/Domain/UserId.php
@@ -41,7 +41,7 @@ final class UserId
      */
     public static function fromString(string $value): self
     {
-        if (1 !== \preg_match('/^@(?P<username>[\da-z0-9_-]+):(?P<homeserver>\S+(\.\S+)+)$/', $value, $matches)) {
+        if (1 !== \preg_match('/^@(?P<username>[\da-z0-9_-\/=.]+):(?P<homeserver>\S+(\.\S+)+)$/', $value, $matches)) {
             throw new \InvalidArgumentException(\sprintf(
                 'Value "%s" does not appear to be a valid Matrix user identifier.',
                 $value,


### PR DESCRIPTION
This pull request adds the characters `=` `/` and `.` to the validation regex of the local part of the matrix user id as specified in the matrix specifications: https://matrix.org/docs/spec/appendices#user-identifiers
